### PR TITLE
fix(print): subtract indent in print statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # My additions
 .vim/
+test.nc
+test2.nc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ncdump-rich"
-version = "0.3.1"
+version = "0.3.2"
 description = "Rich NcDump"
 authors = ["Eirik Enger <eirroleng@gmail.com>"]
 license = "GPL-3.0"

--- a/src/ncdump_rich/ncdump.py
+++ b/src/ncdump_rich/ncdump.py
@@ -7,7 +7,6 @@ so the most important information is presented.
 The flag `-l` `--long` will override the truncation and print a long
 output with all information contained in the .nc file.
 """
-import os
 import pprint
 import textwrap
 
@@ -35,16 +34,11 @@ def ncdump(src_path: str, long: bool = False, truecolor: bool = True) -> None:
         Whether or not nc_attrs, nc_dims, and nc_vars are printed
     """
     nc_file = netCDF4.Dataset(src_path, "r")
-    try:
-        width = os.get_terminal_size()[0]
-    except OSError:
-        width = 150
     if truecolor:
-        console = Console(
-            force_terminal=True, color_system="truecolor", width=width, tab_size=4
-        )
+        console = Console(force_terminal=True, color_system="truecolor", tab_size=4)
     else:
-        console = Console(width=width, tab_size=4)
+        console = Console(tab_size=4)
+    width = console.size.width
     cprint = console.print
 
     def print_ncattr(key: str) -> None:
@@ -146,7 +140,7 @@ def ncdump(src_path: str, long: bool = False, truecolor: bool = True) -> None:
         if len(nc_vars) > 20:
             cprint("\t[italic white]Number of variables: [/italic white]", len(nc_vars))
             cprint("\t[italic white]Variables list: [/italic white]")
-            pp = pprint.PrettyPrinter(width=width, compact=True)
+            pp = pprint.PrettyPrinter(width=width - 8, compact=True)
             cprint(textwrap.indent(pp.pformat(nc_vars), "\t\t"))
         else:
             for var in nc_vars:


### PR DESCRIPTION
The variable list printed when using the `short` option has to get a width that is its indent level less than the full width.